### PR TITLE
[Case 1] Solving packaging problem by inverting dependencies

### DIFF
--- a/case-1/src/main/java/com/company/app/pvmodulelayouts/PvModulesMountedOnRoofFacePlaneLayoutSpecification.java
+++ b/case-1/src/main/java/com/company/app/pvmodulelayouts/PvModulesMountedOnRoofFacePlaneLayoutSpecification.java
@@ -1,9 +1,7 @@
-package com.company.app.pvmodulelayouts.layoutspecification;
+package com.company.app.pvmodulelayouts;
 
 import com.company.app.PvModuleDefinition;
 import com.company.app.PvModulePosition;
-import com.company.app.pvmodulelayouts.LayoutSpecification;
-import com.company.app.pvmodulelayouts.LayoutTile;
 
 import java.util.stream.Stream;
 

--- a/case-1/src/main/java/com/company/app/pvmodulelayouts/PvModulesMountedOnTiltedRacksLayoutSpecification.java
+++ b/case-1/src/main/java/com/company/app/pvmodulelayouts/PvModulesMountedOnTiltedRacksLayoutSpecification.java
@@ -1,9 +1,7 @@
-package com.company.app.pvmodulelayouts.layoutspecification;
+package com.company.app.pvmodulelayouts;
 
 import com.company.app.PvModuleDefinition;
 import com.company.app.PvModulePosition;
-import com.company.app.pvmodulelayouts.LayoutSpecification;
-import com.company.app.pvmodulelayouts.LayoutTile;
 
 import java.util.stream.Stream;
 

--- a/case-1/src/main/java/com/company/app/pvmodulelayouts/defaultlayouts/DefaultPvModuleLayouts.java
+++ b/case-1/src/main/java/com/company/app/pvmodulelayouts/defaultlayouts/DefaultPvModuleLayouts.java
@@ -1,11 +1,13 @@
-package com.company.app.pvmodulelayouts;
+package com.company.app.pvmodulelayouts.defaultlayouts;
 
 import com.company.app.PvModuleDefinition;
 import com.company.app.PvModuleLayouts;
 import com.company.app.PvModulePosition;
 import com.company.app.RoofFace;
-import com.company.app.pvmodulelayouts.layoutspecification.PvModulesMountedOnRoofFacePlaneLayoutSpecification;
-import com.company.app.pvmodulelayouts.layoutspecification.PvModulesMountedOnTiltedRacksLayoutSpecification;
+import com.company.app.pvmodulelayouts.LayoutSpecification;
+import com.company.app.pvmodulelayouts.LayoutTile;
+import com.company.app.pvmodulelayouts.PvModulesMountedOnRoofFacePlaneLayoutSpecification;
+import com.company.app.pvmodulelayouts.PvModulesMountedOnTiltedRacksLayoutSpecification;
 
 import java.util.List;
 import java.util.stream.Stream;

--- a/case-1/src/main/java/com/company/appconfig/App.java
+++ b/case-1/src/main/java/com/company/appconfig/App.java
@@ -1,0 +1,23 @@
+package com.company.appconfig;
+
+import com.company.app.PvModuleDefinition;
+import com.company.app.pvmodulelayouts.defaultlayouts.DefaultPvModuleLayouts;
+
+public final class App {
+    public static void main(String[] args) {
+        new DefaultPvModuleLayouts().optimalLayoutFor(
+            () -> Double.parseDouble(args[0]),
+            new PvModuleDefinition() {
+                @Override
+                public double widthInMeters() {
+                    return Double.parseDouble(args[1]);
+                }
+
+                @Override
+                public double lengthInMeters() {
+                    return Double.parseDouble(args[2]);
+                }
+            }
+        );
+    }
+}


### PR DESCRIPTION
This seems to be the simplest solution. I changed no code, only structure and naming. If the default implementation of the algorithm, `DefaultPvModuleLayouts`, depends on lower level details in a subpackage, then they are not really lower level details. In fact, `DefaultPvModuleLayouts` is supposed to be in a lower level, because it depends on everything and nothing depends on it. Therefore:

- Pull layout specification implementations up into `pvmodulelayouts` package.
- Push `DefaultPvModuleLayouts` into a subpackage. I propose to call it `defaultlayouts` for the default algorithm. Presumably you will need alternative algorithms, they can be put into other subpackages, and they can depend on the same layout specifications in the parent package.

If this is a library, then this is enough, and you can have even stricter rules than the three proposed. Instead of "packages should never depend on sub-packages", you can introduce "packages *can only* depend on superpackages (no sibling dependencies)". If it's a runnable app, however, then you need a place which ties the whole app together, there is no way around that. I usually introduce an `app` package at the root of the project, representing the application fully assembled from all disparate parts from all packages, but since your package structure already has `app`, I introduced `appconfig`, similar as in your solution PR.